### PR TITLE
EOF change and Fix for heap corruption

### DIFF
--- a/src/editline.c
+++ b/src/editline.c
@@ -1407,6 +1407,21 @@ char *readline(const char *prompt)
             }
 
             /*
+            delete until beginning of line
+            */
+            case 0x15:  /* CTRL + U */
+            if (ctrl) {
+              line_len = (int)wcslen(_el_line_buffer);
+              while (rl_point > 0) {
+                if (_el_delete_char(VK_BACK, 1)) {
+                  _el_clean_exit();
+                  return NULL;
+                }
+              }
+              break;
+            }
+
+            /*
             beginning-of-line
             */
             case 0x01:  /* CTRL + A */

--- a/src/editline.c
+++ b/src/editline.c
@@ -1348,6 +1348,19 @@ char *readline(const char *prompt)
             break;
             
             /*
+            EOF
+            */
+            case 0x1A:  /* CTRL + Z */
+            if ((int)wcslen(_el_line_buffer) == 0) {
+              _el_insert_char(_T("^Z"), 2);
+              _el_clean_exit();
+              return NULL;
+            } else {
+              Beep( 800, 200 );
+            }
+            break;
+
+            /*
             delete word
             */
             case 0x17:  /* CTRL + W */

--- a/src/fn_complete.c
+++ b/src/fn_complete.c
@@ -557,6 +557,9 @@ char *rl_filename_completion_function(const char *text, int state)
         continue;
       }
       len = (int)wcslen(filedata.cFileName);
+      /*
+      Directory length + name length + possible quotes + NUL
+      */
       buf_size = dir_name_len + len + 3;
       if (!(_el_compl_array[_el_n_compl] = (wchar_t *)
         malloc(buf_size * sizeof(wchar_t)))) {
@@ -586,10 +589,8 @@ char *rl_filename_completion_function(const char *text, int state)
             _el_compl_array[_el_n_compl], (len + 1) * sizeof(wchar_t));
           _el_compl_array[_el_n_compl][0] = _T('\"');
         }
-        //if (_el_line_buffer[rl_point - last_char_quote] != _T('\"')) {
-          wcscat_s(_el_compl_array[_el_n_compl],
-            dir_name_len + len + 3, _T("\""));
-        //}
+        wcscat_s(_el_compl_array[_el_n_compl],
+          buf_size, _T("\""));
       }
       ++_el_n_compl;
     }


### PR DESCRIPTION
readline() returns NULL when Ctrl-Z is entered at the beginning of a line and beeps if it is entered after other data is already entered.

Fix #2